### PR TITLE
Various cases of invalid URLs have been handled

### DIFF
--- a/gradle-gitignore-plugin/src/main/java/com/github/gregwhitaker/gitignore/tasks/CreateGitIgnoreTask.java
+++ b/gradle-gitignore-plugin/src/main/java/com/github/gregwhitaker/gitignore/tasks/CreateGitIgnoreTask.java
@@ -118,7 +118,7 @@ public class CreateGitIgnoreTask extends DefaultTask {
                 return response.body().string();
             } else {
                 if (response.code() == 404) {
-                    throw new GradleException(String.format("Resource not found. [url: '%s']"));
+                    throw new GradleException(String.format("Resource not found. [url: '%s']", url));
                 }
 
                 throw new GradleException(String.format("Error occurred while retrieving data from url. [code: '%s', url: '%s']", response.code(), url));


### PR DESCRIPTION
Hi, I have added the missing tests for the negative cases to the URLs provided. This is because I found an error in the https://github.com/gregwhitaker/gradle-gitignore/blob/50a2ae9e83bb4d7119853ea19536f0276f0a6074/gradle-gitignore-plugin/src/main/java/com/github/gregwhitaker/gitignore/tasks/CreateGitIgnoreTask.java#L121 file (`url` argument not passed).

Please accept the change quickly ;)